### PR TITLE
Fix: `filterTaps` eliminates accidental clicks

### DIFF
--- a/src/BusMap.js
+++ b/src/BusMap.js
@@ -158,7 +158,8 @@ function ZoomableSVG({children, svgSize={width: 1472.387, height: 2138.5}, step=
                     return [-viewBox.x, -viewBox.y]
                 },
                 rubberband: true,
-                preventDefault: true
+                preventDefault: true,
+                filterTaps: true
             },
             pinch: {
                 preventDefault: true


### PR DESCRIPTION
Closes #10 