### PR TITLE
Switches baselmap to geoportail.lu and fixes problem of maps not showing in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,9 +50,13 @@
   },
   "browserslist": {
     "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
+        ">0.2%", 
+        "not dead", 
+        "not ie 11", 
+        "not chrome < 51", 
+        "not safari < 10", 
+        "not android < 51",
+        "not op_mini all"
     ],
     "development": [
       "last 1 chrome version",

--- a/public/style.json
+++ b/public/style.json
@@ -1,0 +1,2067 @@
+{
+    "version": 8,
+    "name": "Geoportail.lu Road Map",
+    "metadata": {"maputnik:renderer": "mbgljs"},
+    "center": [6.3196318556336, 49.7036243137],
+    "zoom": 8,
+    "bearing": 0,
+    "pitch": 0,
+    "sources": {
+      "geoportail.lu_layers": {
+        "type": "vector",
+        "url": "https://vectortiles.geoportail.lu/data/omt-geoportail-lu.json"
+      },
+      "geoportail.lu_hillshade": {
+        "type": "raster",
+        "url": "https://vectortiles.geoportail.lu/data/hillshade-lu.json",
+        "tileSize": 256
+      },
+      "openmaptiles_osm": {
+        "type": "vector",
+        "url": "https://vectortiles.geoportail.lu/data/omt-osm-cutout-10m.json"
+      }
+    },
+    "glyphs": "https://vectortiles.geoportail.lu/fonts/{fontstack}/{range}.pbf",
+    "layers": [
+      {
+        "id": "background",
+        "type": "background",
+        "layout": {"visibility": "visible"},
+        "paint": {"background-color": "rgba(231, 231, 231, 1)"}
+      },
+      {
+        "id": "landcover_grass",
+        "type": "fill",
+        "source": "openmaptiles_osm",
+        "source-layer": "landcover",
+        "filter": ["==", "class", "grass"],
+        "layout": {"visibility": "none"},
+        "paint": {"fill-color": "rgba(215, 228, 190, 1)", "fill-opacity": 0.45}
+      },
+      {
+        "id": "landcover_wood",
+        "type": "fill",
+        "source": "openmaptiles_osm",
+        "source-layer": "landcover",
+        "filter": ["==", "class", "wood"],
+        "layout": {"visibility": "visible"},
+        "paint": {
+          "fill-color": "rgba(176, 176, 176, 1)",
+          "fill-opacity": {"base": 1, "stops": [[8, 0.6], [22, 1]]}
+        }
+      },
+      {
+        "id": "water",
+        "type": "fill",
+        "source": "openmaptiles_osm",
+        "source-layer": "water",
+        "filter": ["all", ["==", "$type", "Polygon"], ["!=", "intermittent", 1]],
+        "layout": {"visibility": "visible"},
+        "paint": {"fill-color": "rgba(199, 221, 234, 1)"}
+      },
+      {
+        "id": "water_intermittent",
+        "type": "fill",
+        "source": "openmaptiles_osm",
+        "source-layer": "water",
+        "filter": ["all", ["==", "$type", "Polygon"], ["==", "intermittent", 1]],
+        "layout": {"visibility": "visible"},
+        "paint": {"fill-color": "rgba(220, 236, 248, 1)", "fill-opacity": 0.7}
+      },
+      {
+        "id": "landcover-ice-shelf",
+        "type": "fill",
+        "source": "openmaptiles_osm",
+        "source-layer": "landcover",
+        "filter": ["==", "subclass", "ice_shelf"],
+        "layout": {"visibility": "visible"},
+        "paint": {"fill-color": "hsl(47, 26%, 88%)", "fill-opacity": 0.8}
+      },
+      {
+        "id": "landcover-glacier",
+        "type": "fill",
+        "source": "openmaptiles_osm",
+        "source-layer": "landcover",
+        "filter": ["==", "subclass", "glacier"],
+        "layout": {"visibility": "visible"},
+        "paint": {
+          "fill-color": "hsl(47, 22%, 94%)",
+          "fill-opacity": {"base": 1, "stops": [[0, 1], [8, 0.5]]}
+        }
+      },
+      {
+        "id": "landcover_sand",
+        "type": "fill",
+        "metadata": {},
+        "source": "openmaptiles_osm",
+        "source-layer": "landcover",
+        "filter": ["all", ["in", "class", "sand"]],
+        "layout": {"visibility": "visible"},
+        "paint": {
+          "fill-antialias": false,
+          "fill-color": "rgba(248, 238, 160, 1)",
+          "fill-opacity": 0.3
+        }
+      },
+      {
+        "id": "landuse",
+        "type": "fill",
+        "source": "openmaptiles_osm",
+        "source-layer": "landuse",
+        "filter": ["==", "class", "agriculture"],
+        "layout": {"visibility": "visible"},
+        "paint": {"fill-color": "rgba(234, 224, 208, 0.6)"}
+      },
+      {
+        "id": "landuse_overlay_national_park",
+        "type": "fill",
+        "source": "openmaptiles_osm",
+        "source-layer": "landcover",
+        "filter": ["==", "class", "national_park"],
+        "layout": {"visibility": "visible"},
+        "paint": {
+          "fill-color": "rgba(47, 47, 47, 1)",
+          "fill-opacity": {"base": 1, "stops": [[5, 0], [9, 0.75]]}
+        }
+      },
+      {
+        "id": "waterway-tunnel",
+        "type": "line",
+        "source": "openmaptiles_osm",
+        "source-layer": "waterway",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["==", "brunnel", "tunnel"]
+        ],
+        "layout": {"visibility": "visible"},
+        "paint": {
+          "line-color": "rgba(220, 236, 248, 1)",
+          "line-dasharray": [3, 3],
+          "line-gap-width": {"stops": [[12, 0], [20, 6]]},
+          "line-opacity": 1,
+          "line-width": {"base": 1.4, "stops": [[8, 1], [20, 2]]}
+        }
+      },
+      {
+        "id": "waterway",
+        "type": "line",
+        "source": "openmaptiles_osm",
+        "source-layer": "waterway",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["!in", "brunnel", "tunnel", "bridge"],
+          ["!=", "intermittent", 1]
+        ],
+        "layout": {"visibility": "visible"},
+        "paint": {
+          "line-color": "rgba(220, 236, 248, 1)",
+          "line-opacity": 1,
+          "line-width": {"base": 1.4, "stops": [[8, 1], [20, 8]]}
+        }
+      },
+      {
+        "id": "waterway_intermittent",
+        "type": "line",
+        "source": "openmaptiles_osm",
+        "source-layer": "waterway",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["!in", "brunnel", "tunnel", "bridge"],
+          ["==", "intermittent", 1]
+        ],
+        "layout": {"visibility": "visible"},
+        "paint": {
+          "line-color": "rgba(220, 236, 248, 1)",
+          "line-opacity": 1,
+          "line-width": {"base": 1.4, "stops": [[8, 1], [20, 8]]},
+          "line-dasharray": [2, 1]
+        }
+      },
+      {
+        "id": "tunnel_railway_transit",
+        "type": "line",
+        "source": "openmaptiles_osm",
+        "source-layer": "transportation",
+        "minzoom": 0,
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["==", "brunnel", "tunnel"],
+          ["==", "class", "transit"]
+        ],
+        "layout": {
+          "line-cap": "butt",
+          "line-join": "miter",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "rgba(179, 170, 158, 0.3)",
+          "line-dasharray": [3, 3],
+          "line-opacity": {"base": 1, "stops": [[11, 0], [16, 1]]}
+        }
+      },
+      {
+        "id": "building",
+        "type": "fill",
+        "source": "openmaptiles_osm",
+        "source-layer": "building",
+        "paint": {
+          "fill-antialias": true,
+          "fill-color": "rgba(239, 238, 231, 1)",
+          "fill-opacity": {"base": 1, "stops": [[13, 0], [15, 1]]},
+          "fill-outline-color": {
+            "stops": [
+              [15, "rgba(212, 177, 146, 0)"],
+              [16, "rgba(212, 177, 146, 0.1)"]
+            ]
+          }
+        }
+      },
+      {
+        "id": "housenumber",
+        "type": "symbol",
+        "source": "openmaptiles_osm",
+        "source-layer": "housenumber",
+        "minzoom": 17,
+        "filter": ["==", "$type", "Point"],
+        "layout": {
+          "text-field": "{housenumber}",
+          "text-font": ["Noto Sans Regular"],
+          "text-size": 10
+        },
+        "paint": {"text-color": "rgba(212, 177, 146, 0.4)"}
+      },
+      {
+        "id": "road_area_pier",
+        "type": "fill",
+        "metadata": {},
+        "source": "openmaptiles_osm",
+        "source-layer": "transportation",
+        "filter": ["all", ["==", "$type", "Polygon"], ["==", "class", "pier"]],
+        "layout": {"visibility": "visible"},
+        "paint": {"fill-color": "rgba(241, 241, 234, 1)", "fill-antialias": true}
+      },
+      {
+        "id": "tunnel_path",
+        "type": "line",
+        "source": "openmaptiles_osm",
+        "source-layer": "transportation",
+        "minzoom": 0,
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["in", "class", "path"],
+          ["==", "brunnel", "tunnel"]
+        ],
+        "layout": {
+          "line-cap": "square",
+          "line-join": "bevel",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "rgba(247, 247, 247, 1)",
+          "line-dasharray": [2, 2],
+          "line-width": {"base": 1.55, "stops": [[4, 0.25], [14, 1.5], [20, 10]]}
+        }
+      },
+      {
+        "id": "tunnel_track",
+        "type": "line",
+        "source": "openmaptiles_osm",
+        "source-layer": "transportation",
+        "minzoom": 13,
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["in", "class", "track"],
+          ["==", "brunnel", "tunnel"]
+        ],
+        "layout": {
+          "line-cap": "square",
+          "line-join": "bevel",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "rgba(247, 247, 247, 1)",
+          "line-width": {"base": 1.55, "stops": [[4, 0.25], [14, 1.5], [20, 15]]},
+          "line-dasharray": {"stops": [[6, [1, 1]], [13, [8, 4]], [14, [4, 4]]]}
+        }
+      },
+      {
+        "id": "tunnel_minor",
+        "type": "line",
+        "source": "openmaptiles_osm",
+        "source-layer": "transportation",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["==", "brunnel", "tunnel"],
+          ["==", "class", "minor_road"]
+        ],
+        "layout": {
+          "line-cap": "butt",
+          "line-join": "miter",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "#efefef",
+          "line-dasharray": [0.36, 0.18],
+          "line-width": {"base": 1.55, "stops": [[4, 0.25], [20, 30]]}
+        }
+      },
+      {
+        "id": "tunnel_major",
+        "type": "line",
+        "source": "openmaptiles_osm",
+        "source-layer": "transportation",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["==", "brunnel", "tunnel"],
+          ["in", "class", "primary", "secondary", "tertiary", "trunk"]
+        ],
+        "layout": {
+          "line-cap": "butt",
+          "line-join": "miter",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "#fff",
+          "line-dasharray": [0.28, 0.14],
+          "line-width": {"base": 1.4, "stops": [[6, 0.5], [20, 30]]}
+        }
+      },
+      {
+        "id": "road_pier",
+        "type": "line",
+        "metadata": {},
+        "source": "openmaptiles_osm",
+        "source-layer": "transportation",
+        "filter": ["all", ["==", "$type", "LineString"], ["in", "class", "pier"]],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "hsl(47, 26%, 88%)",
+          "line-width": {"base": 1.2, "stops": [[15, 1], [17, 4]]}
+        }
+      },
+      {
+        "id": "road_bridge_area",
+        "type": "fill",
+        "source": "openmaptiles_osm",
+        "source-layer": "transportation",
+        "filter": [
+          "all",
+          ["==", "$type", "Polygon"],
+          ["in", "brunnel", "bridge"]
+        ],
+        "paint": {"fill-color": "rgba(241, 241, 234, 1)", "fill-opacity": 0.5}
+      },
+      {
+        "id": "road_path",
+        "type": "line",
+        "source": "openmaptiles_osm",
+        "source-layer": "transportation",
+        "minzoom": 0,
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["in", "class", "path"],
+          ["!in", "brunnel", "tunnel", "bridge"]
+        ],
+        "layout": {
+          "line-cap": "square",
+          "line-join": "bevel",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "rgba(247, 247, 247, 1)",
+          "line-dasharray": [2, 2],
+          "line-width": {"base": 1.55, "stops": [[4, 0.25], [14, 1.5], [20, 10]]}
+        }
+      },
+      {
+        "id": "road_track",
+        "type": "line",
+        "source": "openmaptiles_osm",
+        "source-layer": "transportation",
+        "minzoom": 13,
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["in", "class", "track"],
+          ["!in", "brunnel", "tunnel", "bridge"]
+        ],
+        "layout": {
+          "line-cap": "square",
+          "line-join": "bevel",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "rgba(247, 247, 247, 1)",
+          "line-width": {"base": 1.55, "stops": [[4, 0.25], [14, 1.5], [20, 15]]},
+          "line-dasharray": {"stops": [[6, [1, 1]], [13, [8, 4]], [14, [4, 4]]]}
+        }
+      },
+      {
+        "id": "road_minor",
+        "type": "line",
+        "source": "openmaptiles_osm",
+        "source-layer": "transportation",
+        "minzoom": 13,
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["in", "class", "minor", "service"]
+        ],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "hsl(0, 0%, 97%)",
+          "line-width": {"base": 1.55, "stops": [[4, 0.25], [20, 30]]}
+        }
+      },
+      {
+        "id": "aeroway-area",
+        "type": "fill",
+        "metadata": {"mapbox:group": "1444849345966.4436"},
+        "source": "openmaptiles_osm",
+        "source-layer": "aeroway",
+        "minzoom": 8,
+        "filter": [
+          "all",
+          ["==", "$type", "Polygon"],
+          ["in", "class", "runway", "taxiway"]
+        ],
+        "layout": {"visibility": "visible"},
+        "paint": {
+          "fill-color": "rgba(238, 238, 238, 1)",
+          "fill-opacity": {"base": 1, "stops": [[10, 0], [14, 1]]},
+          "fill-outline-color": "rgba(112, 112, 112, 0.6)"
+        }
+      },
+      {
+        "id": "aeroway-taxiway",
+        "type": "line",
+        "metadata": {"mapbox:group": "1444849345966.4436"},
+        "source": "openmaptiles_osm",
+        "source-layer": "aeroway",
+        "minzoom": 12,
+        "filter": [
+          "all",
+          ["in", "class", "taxiway"],
+          ["==", "$type", "LineString"]
+        ],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "rgba(255, 255, 255, 1)",
+          "line-opacity": 1,
+          "line-width": {"base": 1.5, "stops": [[12, 1], [17, 10]]}
+        }
+      },
+      {
+        "id": "aeroway-runway",
+        "type": "line",
+        "metadata": {"mapbox:group": "1444849345966.4436"},
+        "source": "openmaptiles_osm",
+        "source-layer": "aeroway",
+        "minzoom": 4,
+        "filter": [
+          "all",
+          ["in", "class", "runway"],
+          ["==", "$type", "LineString"]
+        ],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "rgba(255, 255, 255, 1)",
+          "line-opacity": 1,
+          "line-width": {"base": 1.5, "stops": [[11, 4], [17, 50]]}
+        }
+      },
+      {
+        "id": "road_trunk_primary",
+        "type": "line",
+        "source": "openmaptiles_osm",
+        "source-layer": "transportation",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["in", "class", "trunk", "primary"]
+        ],
+        "layout": {"line-cap": "round", "line-join": "round"},
+        "paint": {
+          "line-color": "#fff",
+          "line-width": {"base": 1.4, "stops": [[6, 0.5], [20, 30]]}
+        }
+      },
+      {
+        "id": "road_secondary_tertiary",
+        "type": "line",
+        "source": "openmaptiles_osm",
+        "source-layer": "transportation",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["in", "class", "secondary", "tertiary"]
+        ],
+        "layout": {"line-cap": "round", "line-join": "round"},
+        "paint": {
+          "line-color": "#fff",
+          "line-width": {"base": 1.4, "stops": [[6, 0.5], [20, 20]]}
+        }
+      },
+      {
+        "id": "road_major_motorway",
+        "type": "line",
+        "source": "openmaptiles_osm",
+        "source-layer": "transportation",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["==", "class", "motorway"]
+        ],
+        "layout": {"line-cap": "round", "line-join": "round"},
+        "paint": {
+          "line-color": "hsl(0, 0%, 100%)",
+          "line-offset": 0,
+          "line-width": {"base": 1.4, "stops": [[8, 1], [16, 10]]}
+        }
+      },
+      {
+        "id": "railway-transit",
+        "type": "line",
+        "source": "openmaptiles_osm",
+        "source-layer": "transportation",
+        "filter": [
+          "all",
+          ["==", "class", "transit"],
+          ["!=", "brunnel", "tunnel"]
+        ],
+        "layout": {"visibility": "visible"},
+        "paint": {
+          "line-color": "rgba(179, 170, 158, 0.25)",
+          "line-opacity": {"base": 1, "stops": [[11, 0], [16, 1]]}
+        }
+      },
+      {
+        "id": "railway",
+        "type": "line",
+        "source": "openmaptiles_osm",
+        "source-layer": "transportation",
+        "filter": ["==", "class", "rail"],
+        "layout": {"visibility": "visible"},
+        "paint": {
+          "line-color": "rgba(179, 170, 158, 0.25)",
+          "line-opacity": {"base": 1, "stops": [[11, 0], [16, 1]]}
+        }
+      },
+      {
+        "id": "waterway-bridge-case",
+        "type": "line",
+        "source": "openmaptiles_osm",
+        "source-layer": "waterway",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["==", "brunnel", "bridge"]
+        ],
+        "layout": {"line-cap": "butt", "line-join": "miter"},
+        "paint": {
+          "line-color": "rgba(222, 222, 222, 1)",
+          "line-gap-width": {"base": 1.55, "stops": [[4, 0.25], [20, 30]]},
+          "line-width": {"base": 1.6, "stops": [[12, 0.5], [20, 10]]}
+        }
+      },
+      {
+        "id": "waterway-bridge",
+        "type": "line",
+        "source": "openmaptiles_osm",
+        "source-layer": "waterway",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["==", "brunnel", "bridge"]
+        ],
+        "layout": {"line-cap": "round", "line-join": "round"},
+        "paint": {
+          "line-color": "rgba(220, 236, 248, 1)",
+          "line-width": {"base": 1.55, "stops": [[4, 0.25], [20, 30]]}
+        }
+      },
+      {
+        "id": "bridge_path-casing",
+        "type": "line",
+        "source": "openmaptiles_osm",
+        "source-layer": "transportation",
+        "minzoom": 13,
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["in", "class", "path"],
+          ["==", "brunnel", "bridge"]
+        ],
+        "layout": {
+          "line-cap": "butt",
+          "line-join": "bevel",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "rgba(201, 201, 201, 1)",
+          "line-width": {"base": 1.55, "stops": [[4, 0.4], [20, 22]]}
+        }
+      },
+      {
+        "id": "bridge_track_casing",
+        "type": "line",
+        "source": "openmaptiles_osm",
+        "source-layer": "transportation",
+        "minzoom": 13,
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["in", "class", "track"],
+          ["==", "brunnel", "bridge"]
+        ],
+        "layout": {
+          "line-cap": "butt",
+          "line-join": "bevel",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "rgba(201, 201, 201, 1)",
+          "line-width": {"base": 1.5, "stops": [[4, 1], [15, 7], [21, 25]]}
+        }
+      },
+      {
+        "id": "bridge_minor case",
+        "type": "line",
+        "source": "openmaptiles_osm",
+        "source-layer": "transportation",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["==", "brunnel", "bridge"],
+          ["==", "class", "minor_road"]
+        ],
+        "layout": {"line-cap": "butt", "line-join": "miter"},
+        "paint": {
+          "line-color": "#dedede",
+          "line-gap-width": {"base": 1.55, "stops": [[4, 0.25], [20, 30]]},
+          "line-width": {"base": 1.6, "stops": [[12, 0.5], [20, 10]]}
+        }
+      },
+      {
+        "id": "bridge_major case",
+        "type": "line",
+        "source": "openmaptiles_osm",
+        "source-layer": "transportation",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["==", "brunnel", "bridge"],
+          ["in", "class", "primary", "secondary", "tertiary", "trunk"]
+        ],
+        "layout": {"line-cap": "butt", "line-join": "miter"},
+        "paint": {
+          "line-color": "#dedede",
+          "line-gap-width": {"base": 1.55, "stops": [[4, 0.25], [20, 30]]},
+          "line-width": {"base": 1.6, "stops": [[12, 0.5], [20, 10]]}
+        }
+      },
+      {
+        "id": "bridge_path",
+        "type": "line",
+        "source": "openmaptiles_osm",
+        "source-layer": "transportation",
+        "minzoom": 13,
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["in", "class", "path"],
+          ["==", "brunnel", "bridge"]
+        ],
+        "layout": {
+          "line-cap": "square",
+          "line-join": "bevel",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "rgba(247, 247, 247, 1)",
+          "line-dasharray": [2, 2],
+          "line-width": {"base": 1.55, "stops": [[4, 0.25], [14, 1.5], [20, 10]]}
+        }
+      },
+      {
+        "id": "bridge_track",
+        "type": "line",
+        "source": "openmaptiles_osm",
+        "source-layer": "transportation",
+        "minzoom": 13,
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["in", "class", "track"],
+          ["==", "brunnel", "bridge"]
+        ],
+        "layout": {
+          "line-cap": "square",
+          "line-join": "bevel",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "rgba(247, 247, 247, 1)",
+          "line-width": {"base": 1.55, "stops": [[4, 0.25], [14, 1.5], [20, 15]]},
+          "line-dasharray": {"stops": [[6, [1, 1]], [13, [8, 4]], [14, [4, 4]]]}
+        }
+      },
+      {
+        "id": "bridge_minor",
+        "type": "line",
+        "source": "openmaptiles_osm",
+        "source-layer": "transportation",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["==", "brunnel", "bridge"],
+          ["==", "class", "minor_road"]
+        ],
+        "layout": {"line-cap": "round", "line-join": "round"},
+        "paint": {
+          "line-color": "#efefef",
+          "line-width": {"base": 1.55, "stops": [[4, 0.25], [20, 30]]}
+        }
+      },
+      {
+        "id": "bridge_major",
+        "type": "line",
+        "source": "openmaptiles_osm",
+        "source-layer": "transportation",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["==", "brunnel", "bridge"],
+          ["in", "class", "primary", "secondary", "tertiary", "trunk"]
+        ],
+        "layout": {"line-cap": "round", "line-join": "round"},
+        "paint": {
+          "line-color": "#fff",
+          "line-width": {"base": 1.4, "stops": [[6, 0.5], [20, 30]]}
+        }
+      },
+      {
+        "id": "poi_label",
+        "type": "symbol",
+        "source": "openmaptiles_osm",
+        "source-layer": "poi",
+        "minzoom": 14,
+        "filter": ["all", ["==", "$type", "Point"], ["==", "rank", 1]],
+        "layout": {
+          "icon-size": 1,
+          "text-anchor": "top",
+          "text-field": "{name:latin}\n{name:nonlatin}",
+          "text-font": ["Noto Sans Regular"],
+          "text-max-width": 8,
+          "text-offset": [0, 0.5],
+          "text-size": 11,
+          "visibility": "visible"
+        },
+        "paint": {
+          "text-color": "rgba(102, 102, 102, 0.3)",
+          "text-halo-blur": 1,
+          "text-halo-color": "rgba(255, 255, 255, 0.3)",
+          "text-halo-width": 1
+        }
+      },
+      {
+        "id": "airport-label",
+        "type": "symbol",
+        "source": "openmaptiles_osm",
+        "source-layer": "aerodrome_label",
+        "minzoom": 10,
+        "filter": ["all", ["has", "iata"]],
+        "layout": {
+          "icon-size": 1,
+          "text-anchor": "top",
+          "text-field": "{name:latin}\n{name:nonlatin}",
+          "text-font": ["Noto Sans Regular"],
+          "text-max-width": 8,
+          "text-offset": [0, 0.5],
+          "text-size": 11,
+          "visibility": "visible"
+        },
+        "paint": {
+          "text-color": "rgba(102, 102, 102, 0.4)",
+          "text-halo-blur": 1,
+          "text-halo-color": "rgba(255, 255, 255, 0.4)",
+          "text-halo-width": 1
+        }
+      },
+      {
+        "id": "road_major_label",
+        "type": "symbol",
+        "source": "openmaptiles_osm",
+        "source-layer": "transportation_name",
+        "filter": ["==", "$type", "LineString"],
+        "layout": {
+          "symbol-placement": "line",
+          "text-field": "{name:latin} {name:nonlatin}",
+          "text-font": ["Noto Sans Regular"],
+          "text-letter-spacing": 0.2,
+          "text-rotation-alignment": "map",
+          "text-size": {"base": 1.2, "stops": [[10, 6], [14, 8]]},
+          "visibility": "visible"
+        },
+        "paint": {
+          "text-color": "rgba(100, 100, 100, 0.3)",
+          "text-halo-color": "rgba(255, 255, 255, 0.3)",
+          "text-halo-width": 2
+        }
+      },
+      {
+        "id": "place_label_other",
+        "type": "symbol",
+        "source": "openmaptiles_osm",
+        "source-layer": "place",
+        "minzoom": 11,
+        "filter": [
+          "all",
+          ["==", "$type", "Point"],
+          [
+            "!in",
+            "class",
+            "city",
+            "state",
+            "country",
+            "continent",
+            "isolated_dwelling"
+          ]
+        ],
+        "layout": {
+          "text-anchor": "center",
+          "text-field": "{name:latin}\n{name:nonlatin}",
+          "text-font": ["Noto Sans Regular"],
+          "text-max-width": 6,
+          "text-size": {"stops": [[11, 19], [15, 24]]},
+          "visibility": "visible"
+        },
+        "paint": {
+          "text-color": "rgba(64, 64, 64, 0.3)",
+          "text-halo-blur": 0,
+          "text-halo-color": "rgba(255, 255, 255, 0.3)",
+          "text-halo-width": 2
+        }
+      },
+      {
+        "id": "place_label_city",
+        "type": "symbol",
+        "source": "openmaptiles_osm",
+        "source-layer": "place",
+        "maxzoom": 24,
+        "filter": ["all", ["==", "$type", "Point"], ["==", "class", "town"]],
+        "layout": {
+          "text-field": "{name:latin}\n{name:nonlatin}",
+          "text-font": ["Noto Sans Regular"],
+          "text-max-width": 10,
+          "text-size": {"stops": [[10, 16], [12, 24]]},
+          "visibility": "visible"
+        },
+        "paint": {
+          "text-color": "rgba(0, 0, 0, 0.25)",
+          "text-halo-blur": 0,
+          "text-halo-color": "hsla(0, 0%, 100%, 0.4)",
+          "text-halo-width": 2
+        }
+      },
+      {
+        "id": "place-label_canton",
+        "type": "symbol",
+        "source": "openmaptiles_osm",
+        "source-layer": "place",
+        "minzoom": 8,
+        "filter": ["all", ["==", "$type", "Point"], ["in", "class", "city"]],
+        "layout": {
+          "text-field": "{name:latin}\n{name:nonlatin}",
+          "text-font": ["Noto Sans Regular"],
+          "text-max-width": 10,
+          "text-size": {"stops": [[10, 18], [12, 26]]},
+          "visibility": "visible"
+        },
+        "paint": {
+          "text-color": "rgba(0, 0, 0, 0.25)",
+          "text-halo-blur": 0,
+          "text-halo-color": "hsla(0, 0%, 100%, 0.4)",
+          "text-halo-width": 2
+        }
+      },
+      {
+        "id": "country_label-other",
+        "type": "symbol",
+        "source": "openmaptiles_osm",
+        "source-layer": "place",
+        "maxzoom": 12,
+        "filter": [
+          "all",
+          ["==", "$type", "Point"],
+          ["==", "class", "country"],
+          ["!has", "iso_a2"]
+        ],
+        "layout": {
+          "text-field": "{name:latin}",
+          "text-font": ["Noto Sans Regular"],
+          "text-max-width": 10,
+          "text-size": {"stops": [[3, 12], [8, 22]]},
+          "visibility": "visible"
+        },
+        "paint": {
+          "text-color": "rgba(33, 33, 33, 0.3)",
+          "text-halo-blur": 0,
+          "text-halo-color": "rgba(255,255,255,0.4)",
+          "text-halo-width": 2
+        }
+      },
+      {
+        "id": "country_label",
+        "type": "symbol",
+        "source": "openmaptiles_osm",
+        "source-layer": "place",
+        "maxzoom": 12,
+        "filter": [
+          "all",
+          ["==", "$type", "Point"],
+          ["==", "class", "country"],
+          ["has", "iso_a2"]
+        ],
+        "layout": {
+          "text-field": "{name:latin}",
+          "text-font": ["Noto Sans Bold"],
+          "text-max-width": 10,
+          "text-size": {"stops": [[3, 12], [8, 22]]},
+          "visibility": "visible"
+        },
+        "paint": {
+          "text-color": "rgba(33, 33, 33, 0.3)",
+          "text-halo-blur": 0,
+          "text-halo-color": "rgba(255, 255, 255, 0.4)",
+          "text-halo-width": 2
+        }
+      },
+      {
+        "id": "hillshade",
+        "type": "raster",
+        "source": "geoportail.lu_hillshade",
+        "minzoom": 0,
+        "maxzoom": 24,
+        "layout": {"visibility": "none"},
+        "paint": {"raster-brightness-min": 0.65}
+      },
+      {
+        "id": "lu_landcover_sand",
+        "type": "fill",
+        "metadata": {},
+        "source": "geoportail.lu_layers",
+        "source-layer": "landcover",
+        "filter": ["all", ["in", "class", "sand"]],
+        "layout": {"visibility": "visible"},
+        "paint": {
+          "fill-antialias": false,
+          "fill-color": "rgba(232, 214, 38, 1)",
+          "fill-opacity": 0.3
+        }
+      },
+      {
+        "id": "lu_landuse_wood",
+        "type": "fill",
+        "source": "geoportail.lu_layers",
+        "source-layer": "landuse_2018",
+        "filter": ["all", ["==", "category", 3]],
+        "layout": {"visibility": "visible"},
+        "paint": {"fill-color": "rgba(131, 174, 174, 1)", "fill-opacity": 0.55}
+      },
+      {
+        "id": "lu_landuse_cemetery",
+        "type": "fill",
+        "source": "geoportail.lu_layers",
+        "source-layer": "landuse",
+        "minzoom": 12,
+        "filter": ["all", ["==", "class", "cemetery"]],
+        "layout": {"visibility": "visible"},
+        "paint": {"fill-color": "rgba(215, 218, 215, 1)", "fill-opacity": 0.6}
+      },
+      {
+        "id": "lu_landuse_stadium",
+        "type": "fill",
+        "source": "geoportail.lu_layers",
+        "source-layer": "landuse",
+        "minzoom": 12,
+        "filter": ["all", ["in", "class", "stadium", "pitch", "track"]],
+        "layout": {"visibility": "visible"},
+        "paint": {"fill-color": "#CAE0BC", "fill-opacity": 1}
+      },
+      {
+        "id": "lu_water",
+        "type": "fill",
+        "source": "geoportail.lu_layers",
+        "source-layer": "water",
+        "filter": ["all", ["==", "$type", "Polygon"], ["!=", "intermittent", 1]],
+        "layout": {"visibility": "visible"},
+        "paint": {"fill-color": "rgba(5, 119, 156, 1)"}
+      },
+      {
+        "id": "lu_water_intermittent",
+        "type": "fill",
+        "source": "geoportail.lu_layers",
+        "source-layer": "water",
+        "filter": ["all", ["==", "$type", "Polygon"], ["==", "intermittent", 1]],
+        "layout": {"visibility": "visible"},
+        "paint": {"fill-color": "hsl(205, 56%, 73%)", "fill-opacity": 0.7}
+      },
+      {
+        "id": "lu_tunnel_railway_transit",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "minzoom": 0,
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["==", "brunnel", "tunnel"],
+          ["==", "class", "transit"]
+        ],
+        "layout": {
+          "line-cap": "butt",
+          "line-join": "miter",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "hsl(34, 12%, 66%)",
+          "line-dasharray": [4, 1.5],
+          "line-opacity": {"base": 1, "stops": [[11, 0], [16, 1]]},
+          "line-width": 1.5
+        }
+      },
+      {
+        "id": "lu_tunnel_railway",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["==", "brunnel", "tunnel"],
+          ["==", "class", "rail"]
+        ],
+        "layout": {
+          "line-cap": "butt",
+          "line-join": "miter",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "hsl(34, 12%, 66%)",
+          "line-opacity": {"base": 1, "stops": [[11, 0], [16, 1]]},
+          "line-dasharray": [4, 1.5],
+          "line-width": 1.5
+        }
+      },
+      {
+        "id": "lu_tunnel_path",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "minzoom": 13,
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["in", "class", "path", "track"],
+          ["==", "nb_voies", 0],
+          ["==", "brunnel", "tunnel"]
+        ],
+        "layout": {
+          "line-cap": "square",
+          "line-join": "bevel",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "rgba(247, 247, 247, 1)",
+          "line-dasharray": [2, 2],
+          "line-width": {"base": 1.55, "stops": [[4, 0.25], [14, 1.5], [20, 10]]}
+        }
+      },
+      {
+        "id": "lu_tunnel_track",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "minzoom": 0,
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["in", "class", "path", "track"],
+          ["==", "nb_voies", 1],
+          ["==", "brunnel", "tunnel"]
+        ],
+        "layout": {
+          "line-cap": "square",
+          "line-join": "bevel",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "rgba(247, 247, 247, 1)",
+          "line-width": {"base": 1.55, "stops": [[4, 0.25], [14, 1.5], [20, 15]]},
+          "line-dasharray": {"stops": [[6, [1, 1]], [13, [8, 4]], [14, [4, 4]]]}
+        }
+      },
+      {
+        "id": "lu_tunnel_minor",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["==", "brunnel", "tunnel"],
+          ["in", "class", "minor_road", "minor", "service"]
+        ],
+        "layout": {
+          "line-cap": "butt",
+          "line-join": "miter",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "#efefef",
+          "line-dasharray": [0.36, 0.18],
+          "line-width": {"base": 1.55, "stops": [[4, 0.25], [20, 30]]}
+        }
+      },
+      {
+        "id": "lu_tunnel_major",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["==", "brunnel", "tunnel"],
+          ["in", "class", "motorway", "primary", "secondary", "tertiary", "trunk"]
+        ],
+        "layout": {
+          "line-cap": "butt",
+          "line-join": "miter",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "#fff",
+          "line-dasharray": [0.28, 0.14],
+          "line-width": {"base": 1.4, "stops": [[6, 0.5], [20, 30]]}
+        }
+      },
+      {
+        "id": "lu_waterway-tunnel",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "waterway",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["==", "brunnel", "tunnel"]
+        ],
+        "layout": {"visibility": "visible"},
+        "paint": {
+          "line-color": "hsl(205, 56%, 73%)",
+          "line-dasharray": [3, 3],
+          "line-gap-width": {"stops": [[12, 0], [20, 6]]},
+          "line-opacity": 1,
+          "line-width": {"base": 1.4, "stops": [[8, 1], [20, 2]]}
+        }
+      },
+      {
+        "id": "lu_waterway",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "waterway",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["!in", "brunnel", "tunnel", "bridge"],
+          ["!=", "intermittent", 1]
+        ],
+        "layout": {"visibility": "visible"},
+        "paint": {
+          "line-color": "rgba(5, 119, 156, 0.63)",
+          "line-opacity": 1,
+          "line-width": {"base": 1.4, "stops": [[8, 1], [20, 8]]}
+        }
+      },
+      {
+        "id": "lu_waterway_intermittent",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "waterway",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["!in", "brunnel", "tunnel", "bridge"],
+          ["==", "intermittent", 1]
+        ],
+        "layout": {"visibility": "visible"},
+        "paint": {
+          "line-color": "rgba(5, 119, 156, 1)",
+          "line-opacity": 1,
+          "line-width": {"base": 1.4, "stops": [[8, 1], [20, 8]]},
+          "line-dasharray": [2, 1]
+        }
+      },
+      {
+        "id": "lu_road_area_pier",
+        "type": "fill",
+        "metadata": {},
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "filter": ["all", ["==", "$type", "Polygon"], ["==", "class", "pier"]],
+        "layout": {"visibility": "visible"},
+        "paint": {"fill-color": "hsl(47, 26%, 88%)", "fill-antialias": true}
+      },
+      {
+        "id": "lu_road_pier",
+        "type": "line",
+        "metadata": {},
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "filter": ["all", ["==", "$type", "LineString"], ["in", "class", "pier"]],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "hsl(47, 26%, 88%)",
+          "line-width": {"base": 1.2, "stops": [[15, 1], [17, 4]]}
+        }
+      },
+      {
+        "id": "lu_road_bridge_area",
+        "type": "fill",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "filter": [
+          "all",
+          ["==", "$type", "Polygon"],
+          ["in", "brunnel", "bridge"]
+        ],
+        "layout": {"visibility": "visible"},
+        "paint": {"fill-color": "hsl(47, 26%, 88%)", "fill-opacity": 0.5}
+      },
+      {
+        "id": "lu_road_path",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "minzoom": 13,
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["in", "class", "path", "track"],
+          ["==", "nb_voies", 0],
+          ["!=", "brunnel", "tunnel"]
+        ],
+        "layout": {
+          "line-cap": "square",
+          "line-join": "bevel",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "rgba(247, 247, 247, 1)",
+          "line-dasharray": [2, 2],
+          "line-width": {"base": 1.55, "stops": [[4, 0.25], [14, 1.5], [20, 10]]}
+        }
+      },
+      {
+        "id": "lu_road_track",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "minzoom": 0,
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["in", "class", "path", "track"],
+          ["==", "nb_voies", 1],
+          ["!=", "brunnel", "tunnel"]
+        ],
+        "layout": {
+          "line-cap": "square",
+          "line-join": "bevel",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "rgba(247, 247, 247, 1)",
+          "line-width": {"base": 1.55, "stops": [[4, 0.25], [14, 1.5], [20, 15]]},
+          "line-dasharray": {"stops": [[6, [1, 1]], [13, [8, 4]], [14, [4, 4]]]}
+        }
+      },
+      {
+        "id": "lu_road_minor",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "minzoom": 12,
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["in", "class", "minor", "service"],
+          ["!=", "brunnel", "tunnel"]
+        ],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "hsl(0, 0%, 97%)",
+          "line-width": {"base": 1.55, "stops": [[4, 0.25], [20, 30]]}
+        }
+      },
+      {
+        "id": "lu_road_trunk_primary",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["in", "class", "trunk", "primary"],
+          ["!=", "brunnel", "tunnel"]
+        ],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "#fff",
+          "line-width": {"base": 1.4, "stops": [[6, 0.5], [20, 30]]}
+        }
+      },
+      {
+        "id": "lu_road_secondary_tertiary",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["in", "class", "secondary", "tertiary"],
+          ["!=", "brunnel", "tunnel"]
+        ],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "#fff",
+          "line-width": {"base": 1.4, "stops": [[6, 0.5], [20, 20]]}
+        }
+      },
+      {
+        "id": "lu_road_major_motorway",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["==", "class", "motorway"],
+          ["!=", "brunnel", "tunnel"]
+        ],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "hsl(0, 0%, 100%)",
+          "line-offset": 0,
+          "line-width": {"base": 1.4, "stops": [[8, 1], [16, 10]]}
+        }
+      },
+      {
+        "id": "lu_tram",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "minzoom": 0,
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["in", "class", "tram", "service"],
+          ["!=", "brunnel", "tunnel"]
+        ],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "hsl(34, 12%, 66%)",
+          "line-opacity": {"base": 1, "stops": [[11, 0], [16, 1]]},
+          "line-width": 1.5
+        }
+      },
+      {
+        "id": "lu_railway-transit",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "filter": [
+          "all",
+          ["==", "class", "transit"],
+          ["!=", "brunnel", "tunnel"]
+        ],
+        "layout": {"visibility": "visible"},
+        "paint": {
+          "line-color": "hsl(34, 12%, 66%)",
+          "line-opacity": {"base": 1, "stops": [[11, 0], [16, 1]]},
+          "line-width": 1.5
+        }
+      },
+      {
+        "id": "lu_railway",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "filter": ["all", ["==", "class", "rail"], ["!=", "brunnel", "tunnel"]],
+        "layout": {"visibility": "visible"},
+        "paint": {
+          "line-color": "hsl(34, 12%, 66%)",
+          "line-opacity": {"base": 1, "stops": [[11, 0], [16, 1]]},
+          "line-width": 1.5
+        }
+      },
+      {
+        "id": "lu_aeroway_area",
+        "type": "fill",
+        "metadata": {"mapbox:group": "1444849345966.4436"},
+        "source": "geoportail.lu_layers",
+        "source-layer": "aeroway",
+        "minzoom": 8,
+        "filter": [
+          "all",
+          ["==", "$type", "Polygon"],
+          ["in", "class", "runway", "taxiway"]
+        ],
+        "layout": {"visibility": "visible"},
+        "paint": {
+          "fill-color": "rgba(244, 244, 244, 1)",
+          "fill-opacity": {"base": 1, "stops": [[10, 0.3], [14, 1]]}
+        }
+      },
+      {
+        "id": "lu_aeroway-taxiway",
+        "type": "line",
+        "metadata": {"mapbox:group": "1444849345966.4436"},
+        "source": "geoportail.lu_layers",
+        "source-layer": "aeroway",
+        "minzoom": 12,
+        "filter": [
+          "all",
+          ["in", "class", "taxiway"],
+          ["==", "$type", "LineString"]
+        ],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "rgba(255, 255, 255, 1)",
+          "line-opacity": 1,
+          "line-width": {"base": 1.5, "stops": [[12, 1], [17, 10]]}
+        }
+      },
+      {
+        "id": "lu_aeroway-runway",
+        "type": "line",
+        "metadata": {"mapbox:group": "1444849345966.4436"},
+        "source": "geoportail.lu_layers",
+        "source-layer": "aeroway",
+        "minzoom": 4,
+        "filter": [
+          "all",
+          ["in", "class", "runway"],
+          ["==", "$type", "LineString"]
+        ],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "rgba(255, 255, 255, 1)",
+          "line-opacity": 1,
+          "line-width": {"base": 1.5, "stops": [[11, 4], [17, 50]]}
+        }
+      },
+      {
+        "id": "lu_building-3d",
+        "type": "fill-extrusion",
+        "source": "geoportail.lu_layers",
+        "source-layer": "building",
+        "layout": {"visibility": "visible"},
+        "paint": {
+          "fill-extrusion-color": "rgba(0, 0, 0, 1)",
+          "fill-extrusion-height": {
+            "property": "render_height",
+            "type": "identity"
+          },
+          "fill-extrusion-base": {
+            "property": "render_min_height",
+            "type": "identity"
+          },
+          "fill-extrusion-opacity": 0.45
+        }
+      },
+      {
+        "id": "lu_waterway-bridge-case",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "waterway",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["==", "brunnel", "bridge"]
+        ],
+        "layout": {
+          "line-cap": "butt",
+          "line-join": "miter",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "#bbbbbb",
+          "line-gap-width": {"base": 1.55, "stops": [[4, 0.25], [20, 30]]},
+          "line-width": {"base": 1.6, "stops": [[12, 0.5], [20, 10]]}
+        }
+      },
+      {
+        "id": "lu_waterway-bridge",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "waterway",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["==", "brunnel", "bridge"]
+        ],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "hsl(205, 56%, 73%)",
+          "line-width": {"base": 1.55, "stops": [[4, 0.25], [20, 30]]}
+        }
+      },
+      {
+        "id": "lu_bridge_railway case",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["==", "brunnel", "bridge"],
+          ["==", "class", "rail"]
+        ],
+        "layout": {
+          "line-cap": "butt",
+          "line-join": "miter",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "#dedede",
+          "line-gap-width": {"base": 1.55, "stops": [[4, 0.2], [20, 5]]},
+          "line-width": {"base": 1.6, "stops": [[12, 0.5], [20, 10]]}
+        }
+      },
+      {
+        "id": "lu_bridge_track-casing",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "minzoom": 13,
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["in", "class", "path", "track"],
+          ["==", "nb_voies", 1],
+          ["==", "brunnel", "bridge"]
+        ],
+        "layout": {
+          "line-cap": "butt",
+          "line-join": "bevel",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "rgba(201, 201, 201, 1)",
+          "line-width": {"base": 1.5, "stops": [[4, 1], [15, 7], [21, 25]]}
+        }
+      },
+      {
+        "id": "lu_bridge_path-casing",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "minzoom": 13,
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["in", "class", "path", "track"],
+          ["==", "nb_voies", 0],
+          ["==", "brunnel", "bridge"]
+        ],
+        "layout": {
+          "line-cap": "butt",
+          "line-join": "bevel",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "rgba(201, 201, 201, 1)",
+          "line-width": {"base": 1.55, "stops": [[4, 0.4], [20, 22]]}
+        }
+      },
+      {
+        "id": "lu_bridge_minor case",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["==", "brunnel", "bridge"],
+          ["in", "class", "minor_road", "minor", "service"]
+        ],
+        "layout": {
+          "line-cap": "butt",
+          "line-join": "miter",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "#dedede",
+          "line-gap-width": {"base": 1.55, "stops": [[4, 0.25], [20, 30]]},
+          "line-width": {"base": 1.6, "stops": [[12, 0.5], [20, 10]]}
+        }
+      },
+      {
+        "id": "lu_bridge_major case",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["==", "brunnel", "bridge"],
+          ["in", "class", "motorway", "primary", "secondary", "tertiary", "trunk"]
+        ],
+        "layout": {
+          "line-cap": "butt",
+          "line-join": "miter",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "#dedede",
+          "line-gap-width": {"base": 1.55, "stops": [[4, 0.25], [20, 30]]},
+          "line-width": {"base": 1.6, "stops": [[12, 0.5], [20, 10]]}
+        }
+      },
+      {
+        "id": "lu_bridge_railway",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["==", "brunnel", "bridge"],
+          ["==", "class", "rail"]
+        ],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "hsl(34, 12%, 66%)",
+          "line-opacity": {"base": 1, "stops": [[11, 0], [16, 1]]},
+          "line-width": 1.5
+        }
+      },
+      {
+        "id": "lu_bridge_path",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "minzoom": 13,
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["in", "class", "path", "track"],
+          ["==", "nb_voies", 0],
+          ["==", "brunnel", "bridge"]
+        ],
+        "layout": {
+          "line-cap": "square",
+          "line-join": "bevel",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "rgba(247, 247, 247, 1)",
+          "line-dasharray": [2, 2],
+          "line-width": {"base": 1.55, "stops": [[4, 0.25], [14, 1.5], [20, 10]]}
+        }
+      },
+      {
+        "id": "lu_bridge_track",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "minzoom": 0,
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["in", "class", "path", "track"],
+          ["==", "nb_voies", 1],
+          ["==", "brunnel", "bridge"]
+        ],
+        "layout": {
+          "line-cap": "square",
+          "line-join": "bevel",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "rgba(247, 247, 247, 1)",
+          "line-width": {"base": 1.55, "stops": [[4, 0.25], [14, 1.5], [20, 15]]},
+          "line-dasharray": {"stops": [[6, [1, 1]], [13, [8, 4]], [14, [4, 4]]]}
+        }
+      },
+      {
+        "id": "lu_bridge_minor",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["==", "brunnel", "bridge"],
+          ["in", "class", "minor_road", "minor", "service"]
+        ],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "hsl(0, 0%, 97%)",
+          "line-width": {"base": 1.55, "stops": [[4, 0.25], [20, 30]]}
+        }
+      },
+      {
+        "id": "lu_bridge_major",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation",
+        "filter": [
+          "all",
+          ["==", "$type", "LineString"],
+          ["==", "brunnel", "bridge"],
+          ["in", "class", "motorway", "primary", "secondary", "tertiary", "trunk"]
+        ],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "#fff",
+          "line-width": {"base": 1.4, "stops": [[6, 0.5], [20, 30]]}
+        }
+      },
+      {
+        "id": "lu_admin_sub",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "boundary",
+        "filter": ["in", "admin_level", 4, 6, 8],
+        "layout": {"visibility": "visible"},
+        "paint": {"line-color": "hsla(0, 0%, 60%, 0.5)", "line-dasharray": [2, 1]}
+      },
+      {
+        "id": "lu_admin_country",
+        "type": "line",
+        "source": "geoportail.lu_layers",
+        "source-layer": "boundary",
+        "filter": [
+          "all",
+          ["<=", "admin_level", 2],
+          ["==", "$type", "LineString"]
+        ],
+        "layout": {"line-cap": "round", "line-join": "round"},
+        "paint": {
+          "line-color": "hsl(0, 0%, 60%)",
+          "line-width": {"base": 1.3, "stops": [[3, 0.5], [22, 15]]}
+        }
+      },
+      {
+        "id": "lu_building_label",
+        "type": "symbol",
+        "source": "geoportail.lu_layers",
+        "source-layer": "building_name",
+        "minzoom": 15,
+        "filter": ["all"],
+        "layout": {
+          "icon-size": 1,
+          "text-field": "{name}",
+          "text-font": ["Noto Sans Bold"],
+          "text-max-width": 6,
+          "text-size": 11,
+          "visibility": "visible"
+        },
+        "paint": {
+          "text-color": "rgba(148, 144, 144, 1)",
+          "text-halo-blur": 0,
+          "text-halo-color": "rgba(217, 213, 215, 1)",
+          "text-halo-width": 0,
+          "text-opacity": 1,
+          "icon-color": "rgba(24, 16, 16, 1)"
+        }
+      },
+      {
+        "id": "lu_road_major_label",
+        "type": "symbol",
+        "source": "geoportail.lu_layers",
+        "source-layer": "transportation_name",
+        "filter": ["==", "$type", "LineString"],
+        "layout": {
+          "symbol-placement": "line",
+          "text-field": "{name}",
+          "text-font": ["Noto Sans Regular"],
+          "text-letter-spacing": 0.1,
+          "text-rotation-alignment": "map",
+          "text-size": {"base": 1.6, "stops": [[10, 10], [20, 12]]},
+          "visibility": "visible"
+        },
+        "paint": {
+          "text-color": "#000",
+          "text-halo-color": "rgba(255, 255, 255, 0.62)",
+          "text-halo-width": 2
+        }
+      },
+      {
+        "id": "lu_place-label_isolated",
+        "type": "symbol",
+        "source": "geoportail.lu_layers",
+        "source-layer": "place",
+        "minzoom": 13,
+        "filter": [
+          "all",
+          ["==", "$type", "Point"],
+          ["in", "class", "isolated_dwelling"]
+        ],
+        "layout": {
+          "text-anchor": "center",
+          "text-field": "{name}",
+          "text-font": ["Noto Sans Regular"],
+          "text-max-width": 6,
+          "text-size": 16,
+          "visibility": "visible"
+        },
+        "paint": {
+          "text-color": "rgba(0, 0, 0, 1)",
+          "text-halo-blur": 0,
+          "text-halo-color": "rgba(255, 255, 255, 0.75)",
+          "text-halo-width": 2
+        }
+      },
+      {
+        "id": "lu_place_label_other",
+        "type": "symbol",
+        "source": "geoportail.lu_layers",
+        "source-layer": "place",
+        "minzoom": 11,
+        "filter": [
+          "all",
+          ["==", "$type", "Point"],
+          [
+            "!in",
+            "class",
+            "city",
+            "commune",
+            "isolated_dwelling",
+            "canton",
+            "state",
+            "country",
+            "continent"
+          ]
+        ],
+        "layout": {
+          "text-anchor": "center",
+          "text-field": "{name}",
+          "text-font": ["Noto Sans Regular"],
+          "text-max-width": 6,
+          "text-size": {"stops": [[11, 19], [15, 24]]},
+          "visibility": "visible"
+        },
+        "paint": {
+          "text-color": "hsl(0, 0%, 25%)",
+          "text-halo-blur": 0,
+          "text-halo-color": "rgba(255, 255, 255, 0.65)",
+          "text-halo-width": 2
+        }
+      },
+      {
+        "id": "lu_place-label_canton",
+        "type": "symbol",
+        "source": "geoportail.lu_layers",
+        "source-layer": "place",
+        "minzoom": 8,
+        "maxzoom": 10,
+        "filter": ["all", ["==", "$type", "Point"], ["in", "class", "canton"]],
+        "layout": {
+          "text-field": "{name}",
+          "text-font": ["Noto Sans Regular"],
+          "text-max-width": 10,
+          "text-size": {"stops": [[10, 16], [12, 24]]},
+          "visibility": "visible"
+        },
+        "paint": {
+          "text-color": "hsl(0, 0%, 0%)",
+          "text-halo-blur": 0,
+          "text-halo-color": "rgba(255, 255, 255, 0.75)",
+          "text-halo-width": 2
+        }
+      },
+      {
+        "id": "lu_place_label_city",
+        "type": "symbol",
+        "source": "geoportail.lu_layers",
+        "source-layer": "place",
+        "minzoom": 10,
+        "maxzoom": 11,
+        "filter": [
+          "all",
+          ["==", "$type", "Point"],
+          ["in", "class", "city", "commune", "canton"]
+        ],
+        "layout": {
+          "text-field": "{name}",
+          "text-font": ["Noto Sans Regular"],
+          "text-max-width": 10,
+          "text-size": {"stops": [[10, 16], [12, 24]]}
+        },
+        "paint": {
+          "text-color": "hsl(0, 0%, 0%)",
+          "text-halo-blur": 0,
+          "text-halo-color": "hsla(0, 0%, 100%, 0.75)",
+          "text-halo-width": 2
+        }
+      },
+      {
+        "id": "lu_country_label-other",
+        "type": "symbol",
+        "source": "geoportail.lu_layers",
+        "source-layer": "place",
+        "maxzoom": 12,
+        "filter": [
+          "all",
+          ["==", "$type", "Point"],
+          ["==", "class", "country"],
+          ["!has", "iso_a2"]
+        ],
+        "layout": {
+          "text-field": "{name}",
+          "text-font": ["Noto Sans Regular"],
+          "text-max-width": 10,
+          "text-size": {"stops": [[3, 12], [8, 22]]},
+          "visibility": "visible"
+        },
+        "paint": {
+          "text-color": "hsl(0, 0%, 13%)",
+          "text-halo-blur": 0,
+          "text-halo-color": "rgba(255,255,255,0.75)",
+          "text-halo-width": 2
+        }
+      },
+      {
+        "id": "lu_country_label",
+        "type": "symbol",
+        "source": "geoportail.lu_layers",
+        "source-layer": "place",
+        "maxzoom": 11,
+        "filter": [
+          "all",
+          ["==", "$type", "Point"],
+          ["==", "class", "country"],
+          ["has", "iso_a2"]
+        ],
+        "layout": {
+          "text-field": "{name}",
+          "text-font": ["Noto Sans Bold"],
+          "text-max-width": 10,
+          "text-size": {"stops": [[3, 12], [8, 22]]},
+          "visibility": "visible"
+        },
+        "paint": {
+          "text-color": "hsl(0, 0%, 13%)",
+          "text-halo-blur": 0,
+          "text-halo-color": "rgba(255,255,255,0.75)",
+          "text-halo-width": 2
+        }
+      },
+      {
+        "id": "lu_airport-symbol",
+        "type": "symbol",
+        "metadata": {"mapbox:group": "1444849345966.4436"},
+        "source": "geoportail.lu_layers",
+        "source-layer": "airport",
+        "minzoom": 9,
+        "filter": ["all", ["==", "nature", 0]],
+        "layout": {
+          "icon-image": {"stops": [[9, "airport-11"], [17, "airport-15"]]},
+          "icon-rotation-alignment": "viewport",
+          "symbol-placement": "point",
+          "icon-size": 1,
+          "symbol-spacing": 5000,
+          "text-field": "",
+          "icon-text-fit": "none",
+          "icon-anchor": "center",
+          "icon-pitch-alignment": "auto",
+          "symbol-avoid-edges": false,
+          "symbol-z-order": "auto",
+          "visibility": "visible"
+        },
+        "paint": {
+          "icon-opacity": 0.7,
+          "text-color": "rgba(0, 0, 0, 1)",
+          "icon-color": "rgba(0, 0, 0, 1)",
+          "text-halo-width": 0
+        }
+      }
+    ],
+    "id": "8u8c58fgw"
+  }

--- a/src/RoadTraffic.js
+++ b/src/RoadTraffic.js
@@ -12,7 +12,6 @@ import {load} from '@loaders.gl/core';
 import DeckGL from '@deck.gl/react';
 import {Map} from 'react-map-gl';
 import maplibregl from 'maplibre-gl';
-import {BASEMAP} from '@deck.gl/carto';
 import {ScatterplotLayer} from '@deck.gl/layers';
 import 'maplibre-gl/dist/maplibre-gl.css';
 
@@ -55,17 +54,18 @@ function StationMap({onSelect=((e) => undefined), countsByStation=[], locationsP
 
   return (
     <DeckGL initialViewState={INITIAL_VIEW_STATE} controller={true} style={{position: 'relative'}} getCursor={({isHovering}) => isHovering ? 'pointer' : 'grab'}>
+      <Map mapLib={maplibregl} mapStyle="style.json" />
       <ScatterplotLayer 
         data={locations}
         opacity={0.8}
         getPosition={({DDLon, DDLat}) => [DDLon, DDLat]}
-        getFillColor={({POSTE_ID}) => countsByStation[POSTE_ID] > 0 ? [255, 140, 0] : [200, 200, 200, 200]}
+        getFillColor={({POSTE_ID}) => countsByStation[POSTE_ID] > 0 ? [38, 122, 166] : [200, 200, 200, 200]}
         getRadius={({POSTE_ID}) => countsByStation[POSTE_ID]}
-        radiusScale={10000 / maxCount}
+        radiusScale={1000 / maxCount}
         radiusMinPixels={3}
         radiusMaxPixels={30}
         pickable={true}
-        highlightColor={[255, 0, 0]}
+        highlightColor={[255, 187, 28]}
         highlightedObjectIndex={selectedStationIndex}
         onClick={({object, index}) => { onSelect(object); setSelectedStationIndex(index) }}
         updateTriggers={{
@@ -73,9 +73,7 @@ function StationMap({onSelect=((e) => undefined), countsByStation=[], locationsP
           getFillColor: countsByStation,
           getPosition: locations
         }}
-      />
-      <Map mapLib={maplibregl} mapStyle={BASEMAP.POSITRON} />
-      
+      />  
     </DeckGL>
   )
 }


### PR DESCRIPTION
Fixes:
* switches the basemap to geoportail.lu through `maplibre-gl` using geportail's MVT service along with a quick and dirty `styles.json` (created from the geoportail template using Maputnik).
* the basemaps now also appear in production. It was just a matter of adjusting the browser whitelist in `package.json`; the webserver headers had nothing to do with it