### PR TITLE
Adds weekly total throughout the year to `CalendarHeatMap`

### DIFF
--- a/src/CalendarHeatMap/CalendarHeatMap.css
+++ b/src/CalendarHeatMap/CalendarHeatMap.css
@@ -1,0 +1,66 @@
+/* progressions generated using https://davidjohnstone.net/lch-lab-colour-gradient-picker
+['#05779c', '#4d7e92', '#6d8588', '#878d7d', '#9e9472', '#b39c66', '#c7a459', '#daab4a', '#edb338', '#ffbb1c']  // LAB blue to yellow
+['#ffbb1c', '#edb338', '#daab4a', '#c7a459', '#b39c66', '#9e9472', '#878d7d', '#6d8588', '#4d7e92', '#05779c']  // LAB yellow to blue
+['#05779c', '#0085a3', '#0093a1', '#009f96', '#00aa84', '#2db46d', '#69bb52', '#9bbf36', '#ccc01d', '#ffbb1c']  // LCH yellow to blue
+['#ffbb1c', '#ccc01d', '#9bbf36', '#69bb52', '#2db46d', '#00aa84', '#009f96', '#0093a1', '#0085a3', '#05779c']  // LCH blue to yellow
+*/
+
+
+rect.heatmap {
+    stroke: none;
+    fill: none;
+    cursor: pointer;
+}
+
+circle.heatmap {
+    stroke: none;
+}
+
+circle.heatmap[data-scaledvalue="null"] {
+    fill: #d3d3d3
+}
+
+circle.heatmap[data-scaledvalue="0"] {
+    fill: #ffbb1c
+}
+
+circle.heatmap[data-scaledvalue="1"] {
+    fill: #ccc01d
+}
+
+circle.heatmap[data-scaledvalue="2"] {
+    fill: #9bbf36
+}
+
+circle.heatmap[data-scaledvalue="3"] {
+    fill: #69bb52
+}
+
+circle.heatmap[data-scaledvalue="4"] {
+    fill: #2db46d
+}
+
+circle.heatmap[data-scaledvalue="5"] {
+    fill: #00aa84
+}
+
+circle[data-scaledvalue="6"] {
+    fill: #009f96
+}
+
+circle[data-scaledvalue="7"] {
+    fill: #0093a1
+}
+
+circle[data-scaledvalue="8"] {
+    fill: #0085a3
+}
+
+circle[data-scaledvalue="9"] {
+    fill: #05779c
+}
+
+/* value "10" is when indeed the maximum value is reached */
+circle[data-scaledvalue="10"] {
+    fill: #05779c
+}

--- a/src/CalendarHeatMap/CalendarHeatMap.css
+++ b/src/CalendarHeatMap/CalendarHeatMap.css
@@ -6,61 +6,61 @@
 */
 
 
-rect.heatmap {
+.heatmap-ui {
     stroke: none;
     fill: none;
     cursor: pointer;
 }
 
-circle.heatmap {
-    stroke: none;
+.heatmap {
+    stroke: black;
 }
 
-circle.heatmap[data-scaledvalue="null"] {
+.heatmap[data-scaledvalue="null"] {
     fill: #d3d3d3
 }
 
-circle.heatmap[data-scaledvalue="0"] {
+.heatmap[data-scaledvalue="0"] {
     fill: #ffbb1c
 }
 
-circle.heatmap[data-scaledvalue="1"] {
+.heatmap[data-scaledvalue="1"] {
     fill: #ccc01d
 }
 
-circle.heatmap[data-scaledvalue="2"] {
+.heatmap[data-scaledvalue="2"] {
     fill: #9bbf36
 }
 
-circle.heatmap[data-scaledvalue="3"] {
+.heatmap[data-scaledvalue="3"] {
     fill: #69bb52
 }
 
-circle.heatmap[data-scaledvalue="4"] {
+.heatmap[data-scaledvalue="4"] {
     fill: #2db46d
 }
 
-circle.heatmap[data-scaledvalue="5"] {
+.heatmap[data-scaledvalue="5"] {
     fill: #00aa84
 }
 
-circle[data-scaledvalue="6"] {
+.heatmap[data-scaledvalue="6"] {
     fill: #009f96
 }
 
-circle[data-scaledvalue="7"] {
+.heatmap[data-scaledvalue="7"] {
     fill: #0093a1
 }
 
-circle[data-scaledvalue="8"] {
+.heatmap[data-scaledvalue="8"] {
     fill: #0085a3
 }
 
-circle[data-scaledvalue="9"] {
+.heatmap[data-scaledvalue="9"] {
     fill: #05779c
 }
 
 /* value "10" is when indeed the maximum value is reached */
-circle[data-scaledvalue="10"] {
+.heatmap[data-scaledvalue="10"] {
     fill: #05779c
 }

--- a/src/CalendarHeatMap/CalendarHeatMap.js
+++ b/src/CalendarHeatMap/CalendarHeatMap.js
@@ -1,0 +1,161 @@
+import { useState, useEffect, useRef, useCallback, useMemo, memo, Suspense, createContext, useContext } from 'react';
+import { animated, useSpring, useSprings, to } from '@react-spring/web'
+import { DateTime } from "luxon";
+import { createUseGesture, dragAction, pinchAction, scrollAction, wheelAction } from '@use-gesture/react'
+import { createMemoryHistory } from '@remix-run/router';
+import { width } from '@mui/system';
+import { ColorRampProperty } from 'maplibre-gl';
+import './CalendarHeatMap.css'
+
+
+export default function CalendarHeatMap({year=2023, yOffset=0, getValues=(x) => x, data={}}) {
+    /* Displays the daily variation of some quantity throughout a year.*/
+
+    const janfirst =  useMemo(() => DateTime.local(year, 1, 1), [year])
+    const values = getValues(data)
+
+    return (
+        <SVGcanvas>
+            <HeatMapMonths year={year} xOffset={150} yOffset={yOffset}/>
+            <HeatMapDayLabels year={year}  />
+            <HeatMapCircles year={year} xOffset={150} yOffset={yOffset} values={values} />
+        </SVGcanvas>
+    )
+        
+}
+
+
+function SVGcanvas({children, width='100%', height='300px', vertical=false}) {
+    return (
+        <svg width={width} height={height} viewBox="0 0 5450 800">
+            {children}
+        </svg>
+    )
+}
+
+
+function HeatMapMonths({year, xOffset=0, yOffset=0}) {
+  const janfirst =  DateTime.local(year, 1, 1);
+  let firstday = janfirst;
+  
+  return (
+    <g>{[...Array(12).keys()].map((i) => {
+      const nextmonth = firstday.plus({months: 1})
+      const lastday = nextmonth.minus({days: 1})
+      const x0 = xOffset + Math.floor((firstday.ordinal - 1 + janfirst.weekday - 1) / 7) * 100
+      const x_firstmonday = x0 + (firstday.weekday == 1 ? 0 : 100)
+      const x1 = xOffset + Math.floor((lastday.ordinal - 1 + janfirst.weekday - 1) / 7) * 100
+      const y0 = yOffset + lastday.weekday * 100
+      const y1 = yOffset + firstday.weekday * 100
+      const ret = (<g key={`heatmap-month-${i}`}>
+        <path 
+          d={`M ${x_firstmonday},${yOffset} L${x1+100},${yOffset} l0,${y0} l-100,0 l0,${700-y0} L${x0},700 l0,${y1 - 700 - 100} L${x_firstmonday},${y1 - 100} z`}
+          style={{fill: i % 2 == 1 ? 'lightgray' : 'none', stroke: 'none'}} 
+        />
+        <text x={x0} y={800} style={{fontSize: '100px'}}>{firstday.toFormat('LLL')}</text>
+      </g>)
+      firstday = nextmonth  // prepare next loop
+      return ret
+    })}</g>
+  )
+}
+
+
+function HeatMapDayLabels({year, yOffset=0, fontSize=60}) {
+  const weekdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+  return (
+      <g>{[...Array(7).keys()].map((i) =>
+          <text key={`heatmap-daylabel-${i}`} x={0} y={yOffset + 50 + i * 100} style={{'fontSize': fontSize, 'alignmentBaseline': 'middle'}}>{weekdays[i]}</text>
+      )}</g> 
+  )
+}
+
+
+function clip(value, min, max) {
+  if (value > max) {
+    return max
+  } else if (value < min) {
+    return min
+  }
+  return value
+}
+
+
+function HeatMapCircles({
+  year, values=[], log=false,
+  minRadius=10, maxRadius=50,
+  minValue=0, maxValue='auto',
+  xOffset=0, yOffset=0,
+  ...args
+}) {
+  const circleDiameter = 2 * maxRadius
+  const displayData = useMemo(() => {
+    const janfirst = DateTime.local(year, 1, 1)
+    const xmax = maxValue == 'auto' ? Math.max(...values) : maxValue
+    const xmin = minValue == 'auto' ? Math.min(...values) : minValue
+  
+    const daily = [...Array(janfirst.daysInYear).keys()].map((i) => {
+      const day = janfirst.plus({days: i})
+      const value = values[i] === undefined ? null : values[i]
+      const scaledValue = value === null ? null : (value - xmin) / xmax
+      const category = value === null ? 'null' : Math.floor(scaledValue * 10)
+      const x = xOffset + Math.floor((i + janfirst.weekday - 1) / 7) * circleDiameter
+      const y = yOffset + (day.weekday - 1) * circleDiameter
+      const r = minRadius + scaledValue * (maxRadius - minRadius)
+      return {i, day, value, category, x, y, r}
+    })
+
+    const weekly = daily.reduce((kv, v) => {
+      if (kv[v.x])
+    }, {})
+  }, [year])
+  
+
+  console.count('heat-map-circles')
+
+  return (
+    <g id='heatmap-circles'>{displayData.map((point) => {
+      return (
+        <g id={`heatmap-day-${point.i}`} key={`heatmap-day-${point.i}`} transform={`translate(${point.x}, ${point.y})`}>
+          <animated.circle key={`heatmap-day-${point.i}-circle`}
+            cx={maxRadius} cy={maxRadius} r={point.r} 
+            className="heatmap"
+            data-value={point.value}
+            data-scaledvalue={point.category}
+          />
+          <rect key={`heatmap-day-${point.i}-rect`}
+            x={0} y={0}
+            width={circleDiameter} height={circleDiameter}
+            className="heatmap"
+            pointerEvents="visible"
+            title={`${point.day.toISODate()}: ${point.value}`}
+          />
+        </g>
+      )    
+    })}</g>
+  )
+}
+
+
+function HeatMapWeekBars({year, values}) {
+  const displayData = useMemo(() => {
+    const janfirst = DateTime.local(year, 1, 1)
+  
+    return [...Array(janfirst.daysInYear).keys()].map((i) => {
+      const day = janfirst.plus({days: i})
+      const value = values[i] === undefined ? null : values[i]
+      return {i, day, value, category, x, y, r}
+    })  
+  }, [year])  
+}
+
+
+function HeatMapDayTooltip({day, value}) {
+    return (
+        <>
+            <p color="inherit">{day.toLocaleString(DateTime.DATE_HUGE)}</p>
+            <p>Boardings: {value === undefined ? '(no data)' : value}</p>
+        </>
+    )
+    
+}

--- a/src/CalendarHeatMap/CalendarHeatMap.js
+++ b/src/CalendarHeatMap/CalendarHeatMap.js
@@ -11,13 +11,12 @@ import './CalendarHeatMap.css'
 export default function CalendarHeatMap({year=2023, yOffset=0, getValues=(x) => x, data={}}) {
     /* Displays the daily variation of some quantity throughout a year.*/
 
-    const janfirst =  useMemo(() => DateTime.local(year, 1, 1), [year])
     const values = getValues(data)
 
     return (
         <SVGcanvas>
             <HeatMapMonths year={year} xOffset={150} yOffset={yOffset}/>
-            <HeatMapDayLabels year={year}  />
+            <HeatMapDayLabels />
             <HeatMapCircles year={year} xOffset={150} yOffset={yOffset} values={values} />
             <line x1="150" y1="0" x2="5450" y2="0" stroke="black" fill="none" />
             <HeatMapWeekBars year={year} xOffset={150} values={values} />
@@ -63,7 +62,7 @@ function HeatMapMonths({year, xOffset=0, yOffset=0}) {
 }
 
 
-function HeatMapDayLabels({year, yOffset=0, fontSize=60}) {
+function HeatMapDayLabels({yOffset=0, fontSize=60}) {
   const weekdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
   return (
       <g>{[...Array(7).keys()].map((i) =>

--- a/src/CalendarHeatMap/index.js
+++ b/src/CalendarHeatMap/index.js
@@ -1,0 +1,2 @@
+import CalendarHeatMap from './CalendarHeatMap.js'
+export default CalendarHeatMap

--- a/src/PageTram.js
+++ b/src/PageTram.js
@@ -1,7 +1,8 @@
 import {useState, useMemo, useTransition} from 'react'
 import Grid from '@mui/material/Grid';
 import { animated, useSpring, config } from '@react-spring/web'
-import { HeatMap } from './BusMap.js'
+//import { HeatMap } from './BusMap.js'
+import CalendarHeatMap from './CalendarHeatMap'
 import { HourlyTraffic } from './RoadTraffic.js'
 
 import Button from '@mui/material/Button';
@@ -56,7 +57,7 @@ export default function PageTram() {
             <Grid item xs={8}>
                 <h1>{currentStop.label}</h1>
                 <AggregateStatistics dailyStats={dailyStats} trend={'+1.4%'} />
-                <HeatMap year={2023} getValues={(x) => x} data={dailyStats} />
+                <CalendarHeatMap year={2023} getValues={(x) => x} data={dailyStats} />
                 <HourlyTraffic countsByHour={hourlyStats} />
             </Grid>
         </Grid>


### PR DESCRIPTION
This is a rather quick-and-dirty fix, adding a bar-plot to the top of `CalendarHeatMap`. It is intended to give a visual impression of the MVP, it is not production ready due to #30, #32 and probably also #31.