### PR TITLE
Add support for themes

### DIFF
--- a/src/BusMapDialog.js
+++ b/src/BusMapDialog.js
@@ -33,6 +33,8 @@ import { animated, useSpring, config } from '@react-spring/web'
 import CalendarHeatMap from './CalendarHeatMap/CalendarHeatMap.js'
 import { HourlyTraffic } from './RoadTraffic.js'
 import { AggregateStatistics, FancyNumber } from './PageTram.js'
+import SingleStat from './DataGrids/SingleStat.js'
+import ComplexStat from './DataGrids/ComplexStat.js'
 
 const Transition = forwardRef(function Transition(props, ref) {
   return <Slide direction="left" ref={ref} {...props} />;
@@ -164,58 +166,3 @@ export default function BusMapDialog() {
 }
 
 
-function SingleStat({title, subtitle=null, caption=null, value, avatar=<></>, unit=undefined}) {
-    return (
-        <Paper sx={{
-            p: 2,
-            display: 'flex',
-            flexDirection: 'column',
-            height: '100%',
-            minWidth: '200px'
-        }}>
-            <Grid container direction="row" justifyContent="space-around" alignItems="stretch" spacing={2}>
-                <Grid item xs="auto">{avatar}</Grid>
-                <Grid item xs>
-                    <Typography variant="h6" color="primary">
-                        {title}
-                    </Typography>
-                    {subtitle && <Typography variant="subtitle">
-                        {subtitle}
-                    </Typography>}
-                    <Typography variant="h4">
-                        <FancyNumber count={value} />{unit === undefined ? '' : `\u202F${unit}`}
-                    </Typography>
-                    <Button color="primary" variant="filledTonal" size="small">last month</Button>
-                    {caption && <Typography variant="caption">
-                        {caption}
-                    </Typography>}
-                    <Typography>
-                    <Button startIcon={<InfoIcon/>} size="small">learn more...</Button>
-                    </Typography>
-                </Grid>
-            </Grid>        
-        </Paper>
-        
-    )
-}
-
-function ComplexStat({children, title, subtitle, caption}) {
-    return (<Paper sx={{
-        p: 2,
-        display: 'flex',
-        flexDirection: 'column',
-        height: '100%',
-        minWidth: '200px'
-    }}>
-        <Typography variant="h6" color="primary">
-            {title}
-        </Typography>
-        {subtitle && <Typography variant="subtitle">
-            {subtitle}
-        </Typography>}
-        {children}
-        {caption && <Typography variant="caption">
-            {caption}
-        </Typography>}
-    </Paper>)
-}

--- a/src/CorridorMap.js
+++ b/src/CorridorMap.js
@@ -1,4 +1,5 @@
 import React, {useEffect, useState} from 'react';
+import { useTheme } from '@mui/material/styles';
 
 
 export function CorridorMap({
@@ -8,7 +9,6 @@ export function CorridorMap({
     onZoneSelected=(zone) => undefined,
     zoneLabel=false
 }) {
-    
     return (
         <svg width="100%"  height="600px" viewBox="0 0 877 1000">
             <g id="zones" style={{display: 'inline'}}>
@@ -31,12 +31,15 @@ export function CorridorMap({
 
 
 function CorridorMultiPolygon({paths, index, opacity=1.0, selected=false, onSelection=(zone) => undefined, value=0}){
+    const theme = useTheme()
+    const color = theme.palette.primary.main_rgb
     return (
         <g 
             id={`zone${index}`}
             pointerEvents="visiblePainted"
             style={{
-                fill: selected ? `red` : `rgba(${Math.round((value > 1 ? 1 : value) * 255)}, 100, 100, ${opacity})`,
+                fill: selected ? theme.palette.secondary.main : theme.palette.primary.main,
+                opacity,
                 stroke: 'white',
                 strokeWidth: 1,
                 strokeLinecap: 'butt',

--- a/src/DataGrids/ComplexStat.js
+++ b/src/DataGrids/ComplexStat.js
@@ -1,0 +1,23 @@
+import Typography from '@mui/material/Typography';
+import Paper from '@mui/material/Paper';
+
+export default function ComplexStat({children, title, subtitle, caption}) {
+    return (<Paper sx={{
+        p: 2,
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        minWidth: '200px'
+    }}>
+        <Typography variant="h6" color="primary">
+            {title}
+        </Typography>
+        {subtitle && <Typography variant="subtitle">
+            {subtitle}
+        </Typography>}
+        {children}
+        {caption && <Typography variant="caption">
+            {caption}
+        </Typography>}
+    </Paper>)
+}

--- a/src/Layout.js
+++ b/src/Layout.js
@@ -81,43 +81,67 @@ const Drawer = styled(MuiDrawer, { shouldForwardProp: (prop) => prop !== 'open' 
   }),
 );
 
-const mdTheme = createTheme();
+function hexToRgb(hex) {
+  var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  return result ? [
+    parseInt(result[1], 16),
+    parseInt(result[2], 16),
+    parseInt(result[3], 16)
+  ] : null;
+}
+
+const themeVars = {
+  palette: {
+    mode: 'light',
+    primary: {
+      main: '#206f89',
+    },
+    secondary: {
+      main: '#ffbb1c',
+    },
+  },
+}
+themeVars.palette.primary.main_rgb = hexToRgb(themeVars.palette.primary.main)
+themeVars.palette.secondary.main_rgb = hexToRgb(themeVars.palette.secondary.main)
+const theme = createTheme(themeVars);
 
 export default function Layout() {
   const [open, setOpen] = React.useState(false);
   const toggleDrawer = () => {
     setOpen(!open);
   };
-  const mdTheme = createTheme();
   const [searchParams, setSearchParams] = useSearchParams();
   const embed = searchParams.get("embed")
 
 
   if (embed) {
     return (
-    <Box 
-      component="main"
-      sx={{
-        backgroundColor: (theme) =>
-          theme.palette.mode === 'light'
-            ? theme.palette.grey[100]
-            : theme.palette.grey[900],
-        flexGrow: 1,
-        height: '100vh',
-        overflow: 'auto',
-      }}
-    >
-      <Container maxWidth="100vw">
-        <ErrorBoundary>
-          <Outlet />
-        </ErrorBoundary>
-        <Copyright sx={{ pt: 4 }} />
-      </Container>
-    </Box>)
+    <ThemeProvider theme={theme}>
+      <Box 
+        component="main"
+        sx={{
+          backgroundColor: (theme) =>
+            theme.palette.mode === 'light'
+              ? theme.palette.grey[100]
+              : theme.palette.grey[900],
+          flexGrow: 1,
+          height: '100vh',
+          overflow: 'auto',
+        }}
+      >
+        <Container maxWidth="100vw">
+          <ErrorBoundary>
+            <Outlet />
+          </ErrorBoundary>
+          <Copyright sx={{ pt: 4 }} />
+        </Container>
+      </Box>
+    </ThemeProvider>
+    )
   }
   
   return (
-    <ThemeProvider theme={mdTheme}>
+    <ThemeProvider theme={theme}>
       <Box sx={{ display: 'flex' }}>
         <AppBar position="absolute" open={open}>
           <Toolbar sx={{ pr: '24px' /* keep right padding when drawer closed */ }} >

--- a/src/PageDemand.js
+++ b/src/PageDemand.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import ErrorBoundary from './ErrorBoundary';
 import Typography from '@mui/material/Typography';
 import Switch from '@mui/material/Switch';
@@ -19,6 +19,8 @@ import IconBus from './ODMIcons/IconBus.js';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
+
+import { useTheme } from '@mui/material/styles';
 
 export default function PageDemand() {
     
@@ -123,10 +125,6 @@ export default function PageDemand() {
 }
 
 
-function LinearColorMap(val) {
-    return `rgb(${val > 1 ? 1 : (val < 0 ? 0 : val) * 255}, 100, 100)`
-}
-
 
 const coords = (alpha=0, {xc=500, yc=500, r=500}={}) => [
     xc + Math.sin(alpha) * r,
@@ -178,12 +176,17 @@ function ModeSplitGraph({
     data=[],
     kind='bar'
 }) {
-
+    const theme = useTheme()
     const total = data.reduce((rv, v) => rv + v, 0)
     let cumsum = 0
+    const colormap = useCallback((k) => {
+        const color = theme.palette.primary.main_rgb.map((v, i) => Math.floor(v - (v - theme.palette.secondary.main_rgb[i]) * k / 3))
+        return `rgb(${color[0]}, ${color[1]}, ${color[2]})`
+    })
+    console.log(colormap(.5))
     const parts = data.map((t, i) => {
         const rel = t / total
-        const ret = {'width': rel, 'left': cumsum, 'right': cumsum + rel, 'color': LinearColorMap(i / 3)}
+        const ret = {'width': rel, 'left': cumsum, 'right': cumsum + rel, 'color': colormap(i)}
         cumsum += rel
         return ret
     })

--- a/src/RoadTraffic.js
+++ b/src/RoadTraffic.js
@@ -1,4 +1,4 @@
-import React, {useState, useEffect, useRef, Suspense} from 'react';
+import React, {useState, useEffect, useRef, Suspense, useMemo} from 'react';
 import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
 import Paper from '@mui/material/Paper';
@@ -35,6 +35,8 @@ import SingleStat from './DataGrids/SingleStat.js';
 
 import Skeleton from '@mui/material/Skeleton';
 
+import { useTheme } from '@mui/material/styles';
+
 
 // Viewport settings
 const INITIAL_VIEW_STATE = {
@@ -59,6 +61,9 @@ function StationMap({onSelect=((e) => undefined), countsByStation=[], locationsP
   }, []) // no need to reload those data
 
   const maxCount = Math.max(...countsByStation.filter(c => Number.isFinite(c)))
+  const theme = useTheme()
+  //const primary = useMemo(() => hexToRgb(theme.palette.primary.main))
+  const primary = theme.palette.primary.main_rgb
 
   return (
     <DeckGL initialViewState={INITIAL_VIEW_STATE} controller={true} style={{position: 'relative', height: '100%'}} getCursor={({isHovering}) => isHovering ? 'pointer' : 'grab'}>
@@ -67,13 +72,13 @@ function StationMap({onSelect=((e) => undefined), countsByStation=[], locationsP
         data={locations}
         opacity={0.8}
         getPosition={({DDLon, DDLat}) => [DDLon, DDLat]}
-        getFillColor={({POSTE_ID}) => countsByStation[POSTE_ID] > 0 ? [38, 122, 166] : [200, 200, 200, 200]}
+        getFillColor={({POSTE_ID}) => countsByStation[POSTE_ID] > 0 ? theme.palette.primary.main_rgb : [200, 200, 200]}
         getRadius={({POSTE_ID}) => countsByStation[POSTE_ID]}
         radiusScale={1000 / maxCount}
         radiusMinPixels={3}
         radiusMaxPixels={30}
         pickable={true}
-        highlightColor={[255, 187, 28]}
+        highlightColor={theme.palette.secondary.main_rgb}
         highlightedObjectIndex={selectedStationIndex}
         onClick={({object, index}) => { onSelect(object); setSelectedStationIndex(index) }}
         updateTriggers={{
@@ -127,11 +132,12 @@ function HeatMap({countsByDay, year}) {
 export function HourlyTraffic({
   countsByHour
 }) {
+  const theme = useTheme()
   return (
     <ErrorBoundary>
       <Chart xExtent={[0, 24]} yExtent={[0, Math.max(...countsByHour.map(c => c.count_weekday), ...countsByHour.map(c => c.count_weekend))]}>
-        <Chart.LineSeries data={countsByHour.map((c) => {return {x: c.hour, y: c.count_weekday}})} stroke="#1976d2" />
-        <Chart.LineSeries data={countsByHour.map((c) => {return {x: c.hour, y: c.count_weekend}})} stroke="gray"/>
+        <Chart.LineSeries data={countsByHour.map((c) => {return {x: c.hour, y: c.count_weekday}})} stroke={theme.palette.primary.main} />
+        <Chart.LineSeries data={countsByHour.map((c) => {return {x: c.hour, y: c.count_weekend}})} stroke={theme.palette.primary.light}/>
       </Chart>
     </ErrorBoundary>
   )


### PR DESCRIPTION
ALong with some other improvements (primarily, not fully functional drawer on tram page and small layout improvements otherwise) this adds a new, central theme to `LAyout.js` using the same color codes as `transports.public.lu` and uses it in the different modules. Should allow for quick and easy color changes. Except: the colormap of the `CalendarHeatMap` is currently hard-coded in CSS